### PR TITLE
When the device is turned off, update state to `OFF`

### DIFF
--- a/zen32_exhaust_fan.yaml
+++ b/zen32_exhaust_fan.yaml
@@ -702,6 +702,19 @@ action:
                 duration: "1:00:00"
               target:
                 entity_id: !input fan_timer
+          - if:
+              - condition: device
+                type: is_off
+                device_id: !input scene_controller
+                entity_id: !input fan_switch
+                domain: switch
+            then:
+              event: ZEN32_EXHAUST_FAN_BLUEPRINT_STATE_CHANGE
+              event_data:
+                scene_controller: !input scene_controller
+                fan_switch: !input fan_switch
+                fan_timer: !input fan_timer
+                new_state: "OFF"
       - conditions: # 45m Button Pressed
           - condition: trigger
             id: zwave_scene_45m


### PR DESCRIPTION
If a person manually turns off the fan by pressing the big button when one of the timers is going, the lights will not update properly and we end up with incorrect state.

This change dispatches an `OFF` state, possibly again, once the switch has been turned off.

Fixes #13